### PR TITLE
Allow to attach response_code tags to response_time metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All options are optional.
 * `protocol` *boolean* include protocol tag. `default = false`
 * `response_code` *boolean* include http response codes. `default = false`
 * `response_code_grouped` *boolean* include http response codes grouped by 100, e.g. 5xx. `default = false`
+* `response_code_tag` *boolean* include http response codes as tags. `default = false`
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = function (options) {
 	var base_url = options.base_url || false;
 	var response_code = options.response_code || false;
 	var response_code_grouped = options.response_code_grouped || false;
+	var response_code_tag = options.response_code_tag || false;
 	var route_tag = typeof options.route_tag === 'function' ? options.route_tag : null;
 
 	return function (req, res, next) {
@@ -45,7 +46,7 @@ module.exports = function (options) {
 				statTags.push("path:" + baseUrl + req.path);
 			}
 
-			if (response_code || response_code_grouped) {
+			if (response_code || response_code_grouped || response_code_tag) {
 				statTags.push("response_code:" + res.statusCode);
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mergermarket/connect-datadog",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
Allow to attach response_code tags to response_time metric without involving response_code.* metrics